### PR TITLE
Add overall cluster status and active shards percent.

### DIFF
--- a/elasticsearch_exporter.go
+++ b/elasticsearch_exporter.go
@@ -358,6 +358,14 @@ var (
 			help:   "Number of data nodes",
 			labels: []string{"cluster"},
 		},
+		"cluster_status": &VecInfo{
+			help:   "Index status (0=green, 1=yellow, 2=red)",
+			labels: []string{"cluster"},
+		},
+		"cluster_active_shards_percent": &VecInfo{
+			help:   "Percent active shards",
+			labels: []string{"cluster"},
+		},
 		"index_status": &VecInfo{
 			help:   "Index status (0=green, 1=yellow, 2=red)",
 			labels: []string{"cluster", "index"},

--- a/elasticsearch_exporter.go
+++ b/elasticsearch_exporter.go
@@ -666,10 +666,13 @@ func (e *Exporter) CollectClusterHealth() {
 		return
 	}
 
+	var statusMap = map[string]float64{"green": 0, "yellow": 1, "red": 2}
+
 	e.gauges["cluster_nodes_total"].WithLabelValues(stats.ClusterName).Set(float64(stats.NumberOfNodes))
 	e.gauges["cluster_nodes_data"].WithLabelValues(stats.ClusterName).Set(float64(stats.NumberOfDataNodes))
+	e.gauges["cluster_status"].WithLabelValues(stats.ClusterName).Set(statusMap[stats.Status])
+	e.gauges["cluster_active_shards_percent"].WithLabelValues(stats.ClusterName).Set(stats.ActiveShardsPercent)
 
-	var statusMap = map[string]float64{"green": 0, "yellow": 1, "red": 2}
 	for indexName, indexStats := range stats.Indices {
 		e.gauges["index_status"].WithLabelValues(stats.ClusterName, indexName).Set(statusMap[indexStats.Status])
 		e.gauges["index_shards_active_primary"].WithLabelValues(stats.ClusterName, indexName).Set(float64(indexStats.ActivePrimaryShards))

--- a/struct.go
+++ b/struct.go
@@ -4,10 +4,12 @@ import "encoding/json"
 
 // Elasticsearch Cluster Health Structs
 type ClusterHealthResponse struct {
-	ClusterName       string `json:"cluster_name"`
-	NumberOfNodes     int64  `json:"number_of_nodes"`
-	NumberOfDataNodes int64  `json:"number_of_data_nodes"`
-	Indices           map[string]ClusterHealthIndexResponse
+	Status              string  `json:"status"`
+	ActiveShardsPercent float64 `json:"active_shards_percent_as_number"`
+	ClusterName         string  `json:"cluster_name"`
+	NumberOfNodes       int64   `json:"number_of_nodes"`
+	NumberOfDataNodes   int64   `json:"number_of_data_nodes"`
+	Indices             map[string]ClusterHealthIndexResponse
 }
 
 type ClusterHealthIndexResponse struct {


### PR DESCRIPTION
This is useful when filtering out index_* metrics when overall status is needed but detailed per index information is not.

As an aside, I noticed go fmt changes the formatting of elasticsearch_exporter.go. I haven't included the go fmt changes in this PR to ensure it merges cleanly, but it's probably worth doing.