### PR TITLE
Report node name instead of node host

### DIFF
--- a/elasticsearch_exporter.go
+++ b/elasticsearch_exporter.go
@@ -135,86 +135,85 @@ var (
 			labels: []string{"cluster", "node"},
 		},
 		"indices_indexing_delete_total": &VecInfo{
-			help: "Total indexing deletes",
+			help:   "Total indexing deletes",
 			labels: []string{"cluster", "node"},
 		},
 		"indices_indexing_delete_time_ms_total": &VecInfo{
-			help: "Total time indexing delete in milliseconds",
+			help:   "Total time indexing delete in milliseconds",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_get_time_ms":           &VecInfo{
-			help: "Total get time in milliseconds",
+		"indices_get_time_ms": &VecInfo{
+			help:   "Total get time in milliseconds",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_get_total":          &VecInfo{
-			help:"Total get",
+		"indices_get_total": &VecInfo{
+			help:   "Total get",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_get_missing_time_ms":        &VecInfo{
-			help:"Total time of get missing in milliseconds",
+		"indices_get_missing_time_ms": &VecInfo{
+			help:   "Total time of get missing in milliseconds",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_get_missing_total":             &VecInfo{
-			help:"Total get missing",
+		"indices_get_missing_total": &VecInfo{
+			help:   "Total get missing",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_get_exists_time_ms":            &VecInfo{
-			help:"Total time get exists in milliseconds",
+		"indices_get_exists_time_ms": &VecInfo{
+			help:   "Total time get exists in milliseconds",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_get_exists_total":           &VecInfo{
-			help:"Total get exists operations",
+		"indices_get_exists_total": &VecInfo{
+			help:   "Total get exists operations",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_search_query_time_ms":          &VecInfo{
-			help: "Total search query time in milliseconds",
+		"indices_search_query_time_ms": &VecInfo{
+			help:   "Total search query time in milliseconds",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_search_query_total":            &VecInfo{
-			help: "Total search queries",
+		"indices_search_query_total": &VecInfo{
+			help:   "Total search queries",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_search_fetch_time_ms":          &VecInfo{
-			help: "Total search fetch time in milliseconds",
+		"indices_search_fetch_time_ms": &VecInfo{
+			help:   "Total search fetch time in milliseconds",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_search_fetch_total":            &VecInfo{
-			help: "Total search fetches",
+		"indices_search_fetch_total": &VecInfo{
+			help:   "Total search fetches",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_translog_operations":           &VecInfo{
-			help: "Total translog operations",
+		"indices_translog_operations": &VecInfo{
+			help:   "Total translog operations",
 			labels: []string{"cluster", "node"},
 		},
-		"indices_translog_size_in_bytes":        &VecInfo{
-			help: "Total translog size in bytes",
+		"indices_translog_size_in_bytes": &VecInfo{
+			help:   "Total translog size in bytes",
 			labels: []string{"cluster", "node"},
 		},
-		"jvm_gc_collection_seconds_count": 	 &VecInfo{
+		"jvm_gc_collection_seconds_count": &VecInfo{
 			help:   "Count of JVM GC runs",
 			labels: []string{"cluster", "node", "gc"},
 		},
-		"jvm_gc_collection_seconds_sum": 	 &VecInfo{
+		"jvm_gc_collection_seconds_sum": &VecInfo{
 			help:   "GC run time in seconds",
 			labels: []string{"cluster", "node", "gc"},
 		},
-		"process_cpu_time_seconds_sum": 	 &VecInfo{
+		"process_cpu_time_seconds_sum": &VecInfo{
 			help:   "Process CPU time in seconds",
 			labels: []string{"cluster", "node", "type"},
 		},
-		"thread_pool_completed_count": 	 	 &VecInfo{
+		"thread_pool_completed_count": &VecInfo{
 			help:   "Thread Pool operations completed",
 			labels: []string{"cluster", "node", "type"},
 		},
-		"thread_pool_rejected_count": 		 &VecInfo{
+		"thread_pool_rejected_count": &VecInfo{
 			help:   "Thread Pool operations rejected",
 			labels: []string{"cluster", "node", "type"},
 		},
-		"http_open_total":                       &VecInfo{
-			help:    "Total HTTP connections opened",
+		"http_open_total": &VecInfo{
+			help:   "Total HTTP connections opened",
 			labels: []string{"cluster", "node"},
 		},
-
 	}
 
 	gaugeMetrics = map[string]*VecInfo{
@@ -306,7 +305,7 @@ var (
 			help:   "Max file descriptors for process",
 			labels: []string{"cluster", "node"},
 		},
-		"os_mem_used_percent":	   &VecInfo{
+		"os_mem_used_percent": &VecInfo{
 			help:   "Percentage of used memory",
 			labels: []string{"cluster", "node"},
 		},
@@ -390,8 +389,8 @@ var (
 			help:   "Number of unassigned shards",
 			labels: []string{"cluster", "index"},
 		},
-		"http_open":                       &VecInfo{
-			help:    "Current HTTP connections opened",
+		"http_open": &VecInfo{
+			help:   "Current HTTP connections opened",
 			labels: []string{"cluster", "node"},
 		},
 	}
@@ -518,128 +517,128 @@ func (e *Exporter) CollectNodesStats() {
 	for _, stats := range allStats.Nodes {
 		// GC Stats
 		for collector, gcstats := range stats.JVM.GC.Collectors {
-			e.counters["jvm_gc_collection_seconds_count"].WithLabelValues(allStats.ClusterName, stats.Host, collector).Set(float64(gcstats.CollectionCount))
-			e.counters["jvm_gc_collection_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Host, collector).Set(float64(gcstats.CollectionTime / 1000))
+			e.counters["jvm_gc_collection_seconds_count"].WithLabelValues(allStats.ClusterName, stats.Name, collector).Set(float64(gcstats.CollectionCount))
+			e.counters["jvm_gc_collection_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Name, collector).Set(float64(gcstats.CollectionTime / 1000))
 		}
 
 		// Breaker stats
 		for breaker, bstats := range stats.Breakers {
-			e.gauges["breakers_estimated_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, breaker).Set(float64(bstats.EstimatedSize))
-			e.gauges["breakers_limit_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, breaker).Set(float64(bstats.LimitSize))
+			e.gauges["breakers_estimated_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name, breaker).Set(float64(bstats.EstimatedSize))
+			e.gauges["breakers_limit_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name, breaker).Set(float64(bstats.LimitSize))
 		}
 
 		// Thread Pool stats
 		for pool, pstats := range stats.ThreadPool {
-			e.counters["thread_pool_completed_count"].WithLabelValues(allStats.ClusterName, stats.Host, pool).Set(float64(pstats.Completed))
-			e.counters["thread_pool_rejected_count"].WithLabelValues(allStats.ClusterName, stats.Host, pool).Set(float64(pstats.Rejected))
+			e.counters["thread_pool_completed_count"].WithLabelValues(allStats.ClusterName, stats.Name, pool).Set(float64(pstats.Completed))
+			e.counters["thread_pool_rejected_count"].WithLabelValues(allStats.ClusterName, stats.Name, pool).Set(float64(pstats.Rejected))
 
-			e.gauges["thread_pool_active_count"].WithLabelValues(allStats.ClusterName, stats.Host, pool).Set(float64(pstats.Active))
-			e.gauges["thread_pool_threads_count"].WithLabelValues(allStats.ClusterName, stats.Host, pool).Set(float64(pstats.Threads))
-			e.gauges["thread_pool_largest_count"].WithLabelValues(allStats.ClusterName, stats.Host, pool).Set(float64(pstats.Largest))
-			e.gauges["thread_pool_queue_count"].WithLabelValues(allStats.ClusterName, stats.Host, pool).Set(float64(pstats.Queue))
+			e.gauges["thread_pool_active_count"].WithLabelValues(allStats.ClusterName, stats.Name, pool).Set(float64(pstats.Active))
+			e.gauges["thread_pool_threads_count"].WithLabelValues(allStats.ClusterName, stats.Name, pool).Set(float64(pstats.Threads))
+			e.gauges["thread_pool_largest_count"].WithLabelValues(allStats.ClusterName, stats.Name, pool).Set(float64(pstats.Largest))
+			e.gauges["thread_pool_queue_count"].WithLabelValues(allStats.ClusterName, stats.Name, pool).Set(float64(pstats.Queue))
 		}
 
 		// JVM Memory Stats
-		e.gauges["jvm_memory_committed_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, "heap").Set(float64(stats.JVM.Mem.HeapCommitted))
-		e.gauges["jvm_memory_used_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, "heap").Set(float64(stats.JVM.Mem.HeapUsed))
-		e.gauges["jvm_memory_max_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, "heap").Set(float64(stats.JVM.Mem.HeapMax))
-		e.gauges["jvm_memory_committed_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, "non-heap").Set(float64(stats.JVM.Mem.NonHeapCommitted))
-		e.gauges["jvm_memory_used_bytes"].WithLabelValues(allStats.ClusterName, stats.Host, "non-heap").Set(float64(stats.JVM.Mem.NonHeapUsed))
+		e.gauges["jvm_memory_committed_bytes"].WithLabelValues(allStats.ClusterName, stats.Name, "heap").Set(float64(stats.JVM.Mem.HeapCommitted))
+		e.gauges["jvm_memory_used_bytes"].WithLabelValues(allStats.ClusterName, stats.Name, "heap").Set(float64(stats.JVM.Mem.HeapUsed))
+		e.gauges["jvm_memory_max_bytes"].WithLabelValues(allStats.ClusterName, stats.Name, "heap").Set(float64(stats.JVM.Mem.HeapMax))
+		e.gauges["jvm_memory_committed_bytes"].WithLabelValues(allStats.ClusterName, stats.Name, "non-heap").Set(float64(stats.JVM.Mem.NonHeapCommitted))
+		e.gauges["jvm_memory_used_bytes"].WithLabelValues(allStats.ClusterName, stats.Name, "non-heap").Set(float64(stats.JVM.Mem.NonHeapUsed))
 
 		// Indices Stats
-		e.gauges["indices_search_query_current"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Search.QueryCurrent))
-		e.gauges["indices_search_open_contexts"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Search.OpenContext))
-		e.gauges["indices_search_fetch_current"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Search.FetchCurrent))
+		e.gauges["indices_search_query_current"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Search.QueryCurrent))
+		e.gauges["indices_search_open_contexts"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Search.OpenContext))
+		e.gauges["indices_search_fetch_current"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Search.FetchCurrent))
 
-		e.gauges["indices_fielddata_memory_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FieldData.MemorySize))
-		e.gauges["indices_fielddata_cache_size"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FieldData.CacheSize))
-		e.counters["indices_fielddata_evictions"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FieldData.Evictions))
-		e.counters["indices_fielddata_hit_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FieldData.HitCount))
-		e.counters["indices_fielddata_total_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FieldData.TotalCount))
+		e.gauges["indices_fielddata_memory_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FieldData.MemorySize))
+		e.gauges["indices_fielddata_cache_size"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FieldData.CacheSize))
+		e.counters["indices_fielddata_evictions"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FieldData.Evictions))
+		e.counters["indices_fielddata_hit_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FieldData.HitCount))
+		e.counters["indices_fielddata_total_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FieldData.TotalCount))
 
-		e.gauges["indices_filter_cache_memory_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FilterCache.MemorySize))
-		e.gauges["indices_filter_cache_cache_size"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FilterCache.CacheSize))
-		e.counters["indices_filter_cache_evictions"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FilterCache.Evictions))
-		e.counters["indices_filter_cache_hit_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FilterCache.HitCount))
-		e.counters["indices_filter_cache_total_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.FilterCache.TotalCount))
+		e.gauges["indices_filter_cache_memory_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FilterCache.MemorySize))
+		e.gauges["indices_filter_cache_cache_size"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FilterCache.CacheSize))
+		e.counters["indices_filter_cache_evictions"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FilterCache.Evictions))
+		e.counters["indices_filter_cache_hit_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FilterCache.HitCount))
+		e.counters["indices_filter_cache_total_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.FilterCache.TotalCount))
 
-		e.gauges["indices_query_cache_memory_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.QueryCache.MemorySize))
-		e.gauges["indices_query_cache_cache_size"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.QueryCache.CacheSize))
-		e.counters["indices_query_cache_evictions"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.QueryCache.Evictions))
-		e.counters["indices_query_cache_hit_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.QueryCache.HitCount))
-		e.counters["indices_query_cache_total_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.QueryCache.TotalCount))
+		e.gauges["indices_query_cache_memory_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.QueryCache.MemorySize))
+		e.gauges["indices_query_cache_cache_size"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.QueryCache.CacheSize))
+		e.counters["indices_query_cache_evictions"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.QueryCache.Evictions))
+		e.counters["indices_query_cache_hit_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.QueryCache.HitCount))
+		e.counters["indices_query_cache_total_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.QueryCache.TotalCount))
 
-		e.gauges["indices_request_cache_memory_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.RequestCache.MemorySize))
-		e.gauges["indices_request_cache_cache_size"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.RequestCache.CacheSize))
-		e.counters["indices_request_cache_evictions"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.RequestCache.Evictions))
-		e.counters["indices_request_cache_hit_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.RequestCache.HitCount))
-		e.counters["indices_request_cache_total_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.RequestCache.TotalCount))
+		e.gauges["indices_request_cache_memory_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.RequestCache.MemorySize))
+		e.gauges["indices_request_cache_cache_size"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.RequestCache.CacheSize))
+		e.counters["indices_request_cache_evictions"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.RequestCache.Evictions))
+		e.counters["indices_request_cache_hit_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.RequestCache.HitCount))
+		e.counters["indices_request_cache_total_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.RequestCache.TotalCount))
 
-		e.counters["indices_translog_operations"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Translog.Operations))
-		e.counters["indices_translog_size_in_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Translog.Size))
+		e.counters["indices_translog_operations"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Translog.Operations))
+		e.counters["indices_translog_size_in_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Translog.Size))
 
-		e.counters["indices_get_time_ms"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Get.Time))
-		e.counters["indices_get_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Get.Total))
+		e.counters["indices_get_time_ms"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Get.Time))
+		e.counters["indices_get_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Get.Total))
 
-		e.counters["indices_get_missing_time_ms"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Get.MissingTime))
-		e.counters["indices_get_missing_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Get.MissingTotal))
+		e.counters["indices_get_missing_time_ms"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Get.MissingTime))
+		e.counters["indices_get_missing_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Get.MissingTotal))
 
-		e.counters["indices_get_exists_time_ms"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Get.ExistsTime))
-		e.counters["indices_get_exists_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Get.ExistsTotal))
+		e.counters["indices_get_exists_time_ms"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Get.ExistsTime))
+		e.counters["indices_get_exists_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Get.ExistsTotal))
 
-		e.counters["indices_search_query_time_ms"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Search.QueryTime))
-		e.counters["indices_search_query_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Search.QueryTotal))
+		e.counters["indices_search_query_time_ms"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Search.QueryTime))
+		e.counters["indices_search_query_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Search.QueryTotal))
 
-		e.counters["indices_search_fetch_time_ms"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Search.FetchTime))
-		e.counters["indices_search_fetch_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Search.FetchTotal))
+		e.counters["indices_search_fetch_time_ms"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Search.FetchTime))
+		e.counters["indices_search_fetch_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Search.FetchTotal))
 
-		e.gauges["indices_docs"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Docs.Count))
-		e.gauges["indices_docs_deleted"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Docs.Deleted))
+		e.gauges["indices_docs"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Docs.Count))
+		e.gauges["indices_docs_deleted"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Docs.Deleted))
 
-		e.gauges["indices_segments_memory_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Segments.Memory))
-		e.gauges["indices_segments_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Segments.Count))
+		e.gauges["indices_segments_memory_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Segments.Memory))
+		e.gauges["indices_segments_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Segments.Count))
 
-		e.gauges["indices_store_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Store.Size))
-		e.counters["indices_store_throttle_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Store.ThrottleTime))
+		e.gauges["indices_store_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Store.Size))
+		e.counters["indices_store_throttle_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Store.ThrottleTime))
 
-		e.counters["indices_flush_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Flush.Total))
-		e.counters["indices_flush_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Flush.Time))
+		e.counters["indices_flush_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Flush.Total))
+		e.counters["indices_flush_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Flush.Time))
 
-		e.counters["indices_indexing_index_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Indexing.IndexTime))
-		e.counters["indices_indexing_index_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Indexing.IndexTotal))
+		e.counters["indices_indexing_index_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Indexing.IndexTime))
+		e.counters["indices_indexing_index_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Indexing.IndexTotal))
 
-		e.counters["indices_indexing_delete_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Indexing.DeleteTime))
-		e.counters["indices_indexing_delete_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Indexing.DeleteTotal))
+		e.counters["indices_indexing_delete_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Indexing.DeleteTime))
+		e.counters["indices_indexing_delete_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Indexing.DeleteTotal))
 
-		e.counters["indices_merges_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Merges.TotalTime))
-		e.counters["indices_merges_size_bytes_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Merges.TotalSize))
-		e.counters["indices_merges_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Merges.Total))
-		e.counters["indices_merges_docs_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Merges.TotalDocs))
+		e.counters["indices_merges_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Merges.TotalTime))
+		e.counters["indices_merges_size_bytes_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Merges.TotalSize))
+		e.counters["indices_merges_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Merges.Total))
+		e.counters["indices_merges_docs_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Merges.TotalDocs))
 
-		e.counters["indices_refresh_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Refresh.TotalTime))
-		e.counters["indices_refresh_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Indices.Refresh.Total))
+		e.counters["indices_refresh_time_ms_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Refresh.TotalTime))
+		e.counters["indices_refresh_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Indices.Refresh.Total))
 
 		// Transport Stats
-		e.counters["transport_rx_packets_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Transport.RxCount))
-		e.counters["transport_rx_size_bytes_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Transport.RxSize))
-		e.counters["transport_tx_packets_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Transport.TxCount))
-		e.counters["transport_tx_size_bytes_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Transport.TxSize))
+		e.counters["transport_rx_packets_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Transport.RxCount))
+		e.counters["transport_rx_size_bytes_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Transport.RxSize))
+		e.counters["transport_tx_packets_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Transport.TxCount))
+		e.counters["transport_tx_size_bytes_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Transport.TxSize))
 
 		// Process Stats
-		e.gauges["process_cpu_percent"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Process.CPU.Percent))
-		e.gauges["process_mem_resident_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Process.Memory.Resident))
-		e.gauges["process_mem_share_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Process.Memory.Share))
-		e.gauges["process_mem_virtual_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Process.Memory.TotalVirtual))
-		e.gauges["process_open_files_count"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Process.OpenFD))
+		e.gauges["process_cpu_percent"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Process.CPU.Percent))
+		e.gauges["process_mem_resident_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Process.Memory.Resident))
+		e.gauges["process_mem_share_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Process.Memory.Share))
+		e.gauges["process_mem_virtual_size_bytes"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Process.Memory.TotalVirtual))
+		e.gauges["process_open_files_count"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Process.OpenFD))
 
-		e.counters["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Host, "total").Set(float64(stats.Process.CPU.Total / 1000))
-		e.counters["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Host, "sys").Set(float64(stats.Process.CPU.Sys / 1000))
-		e.counters["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Host, "user").Set(float64(stats.Process.CPU.User / 1000))
+		e.counters["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Name, "total").Set(float64(stats.Process.CPU.Total / 1000))
+		e.counters["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Name, "sys").Set(float64(stats.Process.CPU.Sys / 1000))
+		e.counters["process_cpu_time_seconds_sum"].WithLabelValues(allStats.ClusterName, stats.Name, "user").Set(float64(stats.Process.CPU.User / 1000))
 
-		e.gauges["os_mem_used_percent"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.OS.Mem.UsedPercent))
+		e.gauges["os_mem_used_percent"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.OS.Mem.UsedPercent))
 		// HTTP Stats
-		e.counters["http_open_total"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Http.TotalOpen))
-		e.gauges["http_open"].WithLabelValues(allStats.ClusterName, stats.Host).Set(float64(stats.Http.CurrentOpen))
+		e.counters["http_open_total"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Http.TotalOpen))
+		e.gauges["http_open"].WithLabelValues(allStats.ClusterName, stats.Name).Set(float64(stats.Http.CurrentOpen))
 
 	}
 }


### PR DESCRIPTION
Host and IP are equal by design and it is much better to report
human-readable node name instead of an IP address.

Related: https://github.com/elastic/elasticsearch/pull/16656